### PR TITLE
Update ledsy.html to catch multiple "play" attempts

### DIFF
--- a/ledsy.html
+++ b/ledsy.html
@@ -435,6 +435,9 @@
 
     //Buttons
     $("#play").click(function () {
+        // Clear previous interval, if set
+        clearInterval(playInterval);
+        // Set new playInterval
         playInterval = setInterval(function () {
             j = ($("#slider-step").slider("value") + 1) % sequenceLength;
             $("#slider-step").slider("value", j);


### PR DESCRIPTION
Clears the playInterval before setting a new one. Under current functionality, clicking "play" will set a new interval each time, where "stop" will only delete the most recently set interval. Thus, clicking "play" multiple times leads to a player that can't be stopped.